### PR TITLE
opts.virtual_fields type is a list as of 1.8

### DIFF
--- a/light_draft/admin.py
+++ b/light_draft/admin.py
@@ -69,7 +69,7 @@ class DraftAdmin(admin.ModelAdmin):
         if form.is_valid():
             # Also proccess m2m fields
             opts = form.instance._meta
-            for f in opts.many_to_many + opts.virtual_fields:
+            for f in opts.many_to_many + tuple(opts.virtual_fields):
                 if not hasattr(f, 'save_form_data'):
                     continue
                 if form._meta.fields and f.name not in form._meta.fields:


### PR DESCRIPTION
My button wasn't working: 500 error of   

```
75.             for f in opts.many_to_many + opts.virtual_fields:

Exception Value: can only concatenate tuple (not "list") to tuple
```

This seemed to fix it.

http://stackoverflow.com/questions/31761009/iterating-over-django-model-attributes